### PR TITLE
Fixed the CReqops.java test

### DIFF
--- a/onesided/CReqops.java
+++ b/onesided/CReqops.java
@@ -53,7 +53,11 @@ public class CReqops
 			//buf = null; //cant initialize a window with a null buffer
 		}
 
-		window = new Win(buf, nproc, 1, MPI.INFO_NULL, MPI.COMM_WORLD);
+                if(nprocs > 4) {
+                        window = new Win(buf, nproc, 1, MPI.INFO_NULL, MPI.COMM_WORLD);
+                } else {
+                        window = new Win(buf, 4, 1, MPI.INFO_NULL, MPI.COMM_WORLD);
+                }
 
 		procNullComm(window, val);
 		getACC(window, rank, buf);


### PR DESCRIPTION
The window used in the test was being created with
size equal to the number of processes. However,
the size needs to be at least 4 for parts of the
test. I modified the test to ensure the window
is always at least size 4.

Signed-off-by: Nathaniel Graham ngraham@lanl.gov

fixes open-mpi/ompi#2081
