### PR TITLE
Fix the WinName.java test

### DIFF
--- a/onesided/WinName.java
+++ b/onesided/WinName.java
@@ -15,23 +15,24 @@ public class WinName {
 	public static void main(String[] args) throws MPIException {
 		String testName = "testName";
 		MPI.Init(args);
-		
+
 		int rank = MPI.COMM_WORLD.getRank();
-	    IntBuffer winArea = MPI.newIntBuffer(1);
+		IntBuffer winArea = MPI.newIntBuffer(1);
 
-	    Win win = new Win(winArea, 1, 1, MPI.INFO_NULL, MPI.COMM_WORLD);
-	    
-	    win.setName(testName);
-	    
-	    if(win.getName().equals(testName)) {
-	    	if(rank == 0) {
-	    		System.out.println("Test Passed");
+		Win win = new Win(winArea, 1, 1, MPI.INFO_NULL, MPI.COMM_WORLD);
+
+		win.setName(testName);
+
+		if(win.getName().equals(testName)) {
+			if(rank == 0) {
+				System.out.println("Test Passed");
+	    		}
+	    	} else {
+	    		if(rank == 0) {
+	    			System.out.println("Test Failed");
+	    		}
 	    	}
-	    } else {
-	    	if(rank == 0) {
-	    		System.out.println("Test Failed");
-	    	}
-	    }
+		win.free();
+		MPI.Finalize();
 	}
-
 }


### PR DESCRIPTION
The window used was not being freed, and MPI
was not being Finalized.

Signed-off-by: Nathaniel Graham ngraham@lanl.gov
