### PR TITLE
Add tests for missing methods

### DIFF
--- a/environment/CommErrhandler.java
+++ b/environment/CommErrhandler.java
@@ -1,0 +1,70 @@
+/*
+ *
+ * File: FileAll.java			Author: Fujitsu
+ *
+ */
+
+import mpi.Errhandler;
+import mpi.MPI;
+import mpi.MPIException;
+
+class CommErrhandler{
+  private final static boolean DEBUG = false;
+
+  public static void main (String[] args) throws MPIException {
+
+    MPI.Init(args);
+    int myrank = MPI.COMM_WORLD.getRank();
+    int size   = MPI.COMM_WORLD.getSize();
+
+    if (myrank == 0) {
+        System.out.println("This program tests call callErrhandler() and generates error messages.\n" +
+                           "ERRORS ARE EXPECTED AND NORMAL IN THIS PROGRAM!!");
+    }
+
+    /* save default error handler (MPI.ERRORS_ARE_FATAL) */
+    Errhandler errhandler = MPI.COMM_WORLD.getErrhandler();
+    if ((myrank == 0) && DEBUG) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " comm.getErrhandler_default() end");
+    }
+    /* set MPI.ERRORS_RETURN */
+    MPI.COMM_WORLD.setErrhandler(MPI.ERRORS_RETURN);
+    if ((myrank == 0) && DEBUG) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " comm.setErrhandler(MPI.ERRORS_RETURN) end");
+    }
+    /* not abend (MPI.ERRORS_RETURN) */
+    MPI.COMM_WORLD.callErrhandler(MPI.ERR_COMM);
+    if ((myrank == 0) && DEBUG) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " comm.callErrhandler_1() end");
+    }
+
+    MPI.COMM_WORLD.barrier();
+
+    /* restore default error handler (MPI.ERRORS_ARE_FATAL) */
+    MPI.COMM_WORLD.setErrhandler(errhandler);
+    if ((myrank == 0)  && DEBUG) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " comm.setErrhandler(restore) end");
+    }
+
+    /* abend (MPI.ERRORS_ARE_FATAL) */
+    MPI.COMM_WORLD.callErrhandler(MPI.ERR_COMM);
+    if (myrank == 0) {
+      OmpitestError.ompitestError(OmpitestError.getFileName(),
+                                  OmpitestError.getLineNumber(),
+                                  "Error: The behavior of callErrhandler() is abnormal.");
+    }
+
+    MPI.COMM_WORLD.barrier();
+
+    MPI.Finalize();
+
+    if (myrank == 0) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " MPI.Finalize() end");
+    }
+  }
+}

--- a/environment/FileErrhandler.java
+++ b/environment/FileErrhandler.java
@@ -1,0 +1,83 @@
+/*
+ *
+ * File: FileAll.java			Author: Fujitsu
+ *
+ */
+
+import mpi.Errhandler;
+import mpi.File;
+import mpi.MPI;
+import mpi.MPIException;
+
+class FileErrhandler{
+  private final static boolean DEBUG = false;
+
+  public static void main (String[] args) throws MPIException {
+    MPI.Init(args);
+    int myrank = MPI.COMM_WORLD.getRank();
+    int size   = MPI.COMM_WORLD.getSize();
+
+    
+    String filename = "ompi_testfile." + myrank;
+    File file = new File(MPI.COMM_SELF, filename,
+                         MPI.MODE_WRONLY | MPI.MODE_CREATE);
+
+    if(myrank == 0) {
+        System.out.println("This program tests call callErrhandler() and generates error messages.\n" +
+                           "ERRORS ARE EXPECTED AND NORMAL IN THIS PROGRAM!!");
+    }
+
+    /* set MPI.ERRORS_ARE_FATAL */
+    file.setErrhandler(MPI.ERRORS_ARE_FATAL);
+    if ((myrank == 0) && DEBUG) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " file.setErrhandler(MPI.ERRORS_ARE_FATAL) end");
+    }
+
+    /* save error handler (MPI.ERRORS_ARE_FATAL) */
+    Errhandler errhandler = file.getErrhandler();
+    if ((myrank == 0) && DEBUG) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " file.getErrhandler_fatal(MPI.ERRORS_ARE_FATAL) end");
+    }
+    /* set MPI.ERRORS_RETURN */
+    file.setErrhandler(MPI.ERRORS_RETURN);
+    if ((myrank == 0) && DEBUG) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " file.setErrhandler(MPI.ERRORS_RETURN) end");
+    }
+    /* not abend (MPI.ERRORS_RETURN) */
+    file.callErrhandler(MPI.ERR_FILE);
+    if ((myrank == 0) && DEBUG) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " file.callErrhandler_1() end");
+    }
+
+    MPI.COMM_WORLD.barrier();
+
+    /* restore error handler (MPI.ERRORS_ARE_FATAL) */
+    file.setErrhandler(errhandler);
+    if ((myrank == 0) && DEBUG) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " file.setErrhandler(restore) end");
+    }
+
+    /* abend (MPI.ERRORS_ARE_FATAL) */
+    file.callErrhandler(MPI.ERR_FILE);
+    if (myrank == 0) {
+      OmpitestError.ompitestError(OmpitestError.getFileName(),
+                                  OmpitestError.getLineNumber(),
+                                  "Error: The behavior of callErrhandler() is abnormal.");
+    }
+
+    MPI.COMM_WORLD.barrier();
+    File.delete(filename);
+    MPI.Finalize();
+
+    if ((myrank == 0)  && DEBUG) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " MPI.Finalize() end");
+    }
+  }
+}
+

--- a/environment/WinErrhandler.java
+++ b/environment/WinErrhandler.java
@@ -1,0 +1,76 @@
+/*
+ *
+ * File: FileAll.java			Author: Fujitsu
+ *
+ */
+
+import java.nio.IntBuffer;
+
+import mpi.Errhandler;
+import mpi.MPI;
+import mpi.MPIException;
+import mpi.Win;
+
+class WinErrhandler{
+  private final static boolean DEBUG = false;
+
+  public static void main (String[] args) throws MPIException {
+
+    MPI.Init(args);
+    int myrank = MPI.COMM_WORLD.getRank();
+    int size   = MPI.COMM_WORLD.getSize();
+
+    if (myrank == 0) {
+        System.out.println("This program tests call callErrhandler() and generates error messages.\n" +
+                           "ERRORS ARE EXPECTED AND NORMAL IN THIS PROGRAM!!");
+    }
+
+    IntBuffer buffer = MPI.newIntBuffer(1);
+    Win win = new Win(buffer, 1, 1, MPI.INFO_NULL, MPI.COMM_WORLD);
+
+    /* save default error handler (MPI.ERRORS_ARE_FATAL) */
+    Errhandler errhandler = win.getErrhandler();
+    if ((myrank == 0) && DEBUG) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " win.getErrhandler_default() end");
+    }
+    /* set MPI.ERRORS_RETURN */
+    win.setErrhandler(MPI.ERRORS_RETURN);
+    if ((myrank == 0) && DEBUG) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " win.setErrhandler(MPI.ERRORS_RETURN) end");
+    }
+    /* not abend (MPI.ERRORS_RETURN) */
+    win.callErrhandler(MPI.ERR_WIN);
+    if ((myrank == 0) && DEBUG) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " win.callErrhandler_1() end");
+    }
+
+    MPI.COMM_WORLD.barrier();
+
+    /* restore default error handler (MPI.ERRORS_ARE_FATAL) */
+    win.setErrhandler(errhandler);
+    if ((myrank == 0)  && DEBUG) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " win.setErrhandler(restore) end");
+    }
+
+    /* abend (MPI.ERRORS_ARE_FATAL) */
+    win.callErrhandler(MPI.ERR_WIN);
+    if (myrank == 0) {
+      OmpitestError.ompitestError(OmpitestError.getFileName(),
+                                  OmpitestError.getLineNumber(),
+                                  "Error: The behavior of callErrhandler() is abnormal.");
+    }
+
+    MPI.COMM_WORLD.barrier();
+
+    MPI.Finalize();
+
+    if (myrank == 0) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " MPI.Finalize() end");
+    }
+  }
+}

--- a/environment/make_environment
+++ b/environment/make_environment
@@ -33,7 +33,10 @@ IsThrMain \
 Pcontrol \
 Procname \
 QueryThread \
-Wtime"
+Wtime \
+WinErrhandler \
+CommErrhandler \
+FileErrhandler"
 
 NUM_PROC=$TWO_PROC
 

--- a/io/FileAll.java
+++ b/io/FileAll.java
@@ -1,0 +1,94 @@
+/*
+ *
+ * File: FileAll.java			Author: Fujitsu
+ *
+ */
+
+import java.nio.IntBuffer;
+
+import mpi.File;
+import mpi.MPI;
+import mpi.MPIException;
+import mpi.Request;
+
+public class  FileAll
+{
+  private static final int ITEMS = 50;
+  private static final int SIZEOF_INT = 4;
+  private final static boolean DEBUG = false;
+
+  public static void main (String args[]) throws MPIException
+  {
+    int myrank, size;
+    Request req1, req2;
+    File file;
+
+    MPI.Init(args);
+    myrank = MPI.COMM_WORLD.getRank();
+    size = MPI.COMM_WORLD.getSize();
+
+    /* Do this on every node, because in a testing environment, we can't
+     * assume a common filesystem
+     */
+    String filename = "ompi_testfile_all";
+
+    /* iWriteAtAll */
+    file = new File(MPI.COMM_WORLD, filename,
+                       MPI.MODE_WRONLY | MPI.MODE_CREATE);
+
+    IntBuffer buffer = MPI.newIntBuffer(ITEMS);
+    for (int i = 0; i < ITEMS; ++i) {
+      buffer.put(i, i*100*(myrank+1));   // myrank=0: 0,100,200,300..., myrank=1: 0,200,400,600..., myrank=2: 0,300,600,900...
+    }
+    file.setView(myrank * ITEMS * SIZEOF_INT, MPI.INT, MPI.INT, "native");
+    req1 = file.iWriteAll(buffer, ITEMS, MPI.INT);
+    req1.waitFor();
+
+    if ((myrank == 0) && DEBUG) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " file.iWriteAll() end");
+    }
+
+    file.close();
+
+    /* iReadAtAll */
+    file = new File(MPI.COMM_WORLD, filename, MPI.MODE_RDONLY);
+    file.setView(myrank * ITEMS * SIZEOF_INT, MPI.INT, MPI.INT, "native");
+    req2 = file.iReadAll(buffer, ITEMS, MPI.INT);
+    req2.waitFor();
+
+    /* printing read data */
+    for (int i = 0; i < ITEMS; ++i) {
+      if (buffer.get(i) != i*100*(myrank+1)){
+    	  OmpitestError.ompitestError(OmpitestError.getFileName(),
+    			  OmpitestError.getLineNumber(),
+    			  "myrank " + myrank + " of " + size +
+    			  " data incorrect, read data=" + buffer.get(i) +
+    			  ", expected data=" + i*100*(myrank+1));
+      }
+    }
+
+    if ((myrank == 0) && DEBUG) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " file.iReadAll() end");
+    }
+
+    file.close();
+
+    /* Delete the testfile.
+     * original file: unlink(filename);
+     * The second parameter is an info object.
+     */
+    MPI.COMM_WORLD.barrier();
+    if(myrank == 0) {
+      File.delete(filename);
+    }
+    MPI.Finalize();
+
+    if ((myrank == 0) && DEBUG) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " MPI.Finalize() end");
+    }
+
+  }
+}

--- a/io/FileAtAll.java
+++ b/io/FileAtAll.java
@@ -1,0 +1,91 @@
+/*
+ * File: FileAll.java			Author: Fujitsu
+ *
+ */
+
+import java.nio.IntBuffer;
+
+import mpi.File;
+import mpi.MPI;
+import mpi.MPIException;
+import mpi.Request;
+
+public class  FileAtAll
+{
+  private static final int ITEMS = 50;
+  private static final int SIZEOF_INT = 4;
+  private final static boolean DEBUG = false;
+
+  public static void main (String args[]) throws MPIException
+  {
+    int myrank, size;
+    Request req1, req2;
+    File file;
+
+    MPI.Init(args);
+    myrank = MPI.COMM_WORLD.getRank();
+    size = MPI.COMM_WORLD.getSize();
+
+    /* Do this on every node, because in a testing environment, we can't
+     * assume a common filesystem
+     */
+    String filename = "ompi_testfile_at_all";
+
+    /* iWriteAtAll */
+    file = new File(MPI.COMM_WORLD, filename,
+                       MPI.MODE_WRONLY | MPI.MODE_CREATE);
+
+    IntBuffer buffer = MPI.newIntBuffer(ITEMS);
+    for (int i = 0; i < ITEMS; ++i) {
+      buffer.put(i, i*10*(myrank+1));   // myrank=0: 0,10,20,30..., myrank=1: 0,20,40,60..., myrank=2: 0,30,60,90...
+    }
+    req1 = file.iWriteAtAll(myrank * ITEMS * SIZEOF_INT, buffer, ITEMS, MPI.INT);
+    req1.waitFor();
+
+    if ((myrank == 0) && DEBUG) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " file.iWriteAtAll() end");
+    }
+
+    file.close();
+
+    /* iReadAtAll */
+    file = new File(MPI.COMM_WORLD, filename, MPI.MODE_RDONLY);
+    req2 = file.iReadAtAll(myrank * ITEMS * SIZEOF_INT, buffer, ITEMS, MPI.INT);
+    req2.waitFor();
+
+    /* printing read data */
+    for (int i = 0; i < ITEMS; ++i) {
+      if (buffer.get(i) != i*10*(myrank+1)){
+    	OmpitestError.ompitestError(OmpitestError.getFileName(),
+    			OmpitestError.getLineNumber(),
+    			"myrank " + myrank + " of " + size +
+    			" data incorrect, read data=" + buffer.get(i) +
+    			", expected data=" + i*10*(myrank+1));
+      }
+    }
+
+    if ((myrank == 0) && DEBUG) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " file.iReadAtAll() end");
+    }
+
+    file.close();
+
+    /* Delete the testfile.
+     * original file: unlink(filename);
+     * The second parameter is an info object.
+     */
+    MPI.COMM_WORLD.barrier();
+    if(myrank == 0) {
+      File.delete(filename);
+    }
+
+    MPI.Finalize();
+
+    if ((myrank == 0) && DEBUG) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " MPI.Finalize() end");
+    }
+  }
+}

--- a/io/FileAtomicity.java
+++ b/io/FileAtomicity.java
@@ -1,0 +1,97 @@
+/*
+ *
+ * File: FileAll.java			Author: Fujitsu
+ *
+ */
+
+import mpi.File;
+import mpi.MPI;
+import mpi.MPIException;
+
+class  FileAtomicity{
+  private final static boolean DEBUG = false;
+
+  public static void main (String args[]) throws MPIException{
+
+    boolean atomicity;
+
+    MPI.Init(args);
+    int myrank = MPI.COMM_WORLD.getRank();
+    int size = MPI.COMM_WORLD.getSize();
+
+    /* Do this on every node, because in a testing environment, we can't
+     * assume a common filesystem
+     */
+    String filename = "ompi_testfile." + myrank;
+
+    File file = new File(MPI.COMM_SELF, filename,
+                         MPI.MODE_WRONLY | MPI.MODE_CREATE);
+
+    /* setAtomicity (true) */
+    file.setAtomicity(true);
+    if ((myrank == 0) && DEBUG) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " file.setAtomicity()  end");
+    }
+    /* getAtomicity (true) */
+    atomicity = file.getAtomicity();
+    if (atomicity != true) {
+        if(DEBUG) {
+          System.out.println("myrank " + myrank + " of " + size +
+                             " file.getAtomicity()  error" +
+                             " setvalue= " + true  + " atomicity=" + atomicity);
+        }
+      MPI.COMM_WORLD.abort(100);
+    }else{
+      if (myrank == 0) {
+         if(DEBUG) {
+            System.out.println("myrank " + myrank + " of " + size +
+                               " file.getAtomicity()  end(OK)" +
+                               " atomicity=" + atomicity);
+        }
+      }
+    }
+
+    /* setAtomicity (false) */
+    file.setAtomicity(false);
+    /* getAtomicity (false) */
+    atomicity = file.getAtomicity();
+    if (atomicity != false) {
+    	OmpitestError.ompitestError(OmpitestError.getFileName(),
+    			OmpitestError.getLineNumber(),
+    			"myrank " + myrank + " of " + size +
+    			 " file.getAtomicity()  error" +
+    			 " setvalue= " + false  + " atomicity=" + atomicity);
+
+/*
+      System.out.println("myrank " + myrank + " of " + size +
+                         " file.getAtomicity()  error" +
+                         " setvalue= " + false  + " atomicity=" + atomicity + "\n");
+*/
+      MPI.COMM_WORLD.abort(100);
+    }else{
+      if ((myrank == 0) && DEBUG) {
+        System.out.println("myrank " + myrank + " of " + size +
+                           " file.getAtomicity()  end(OK)" +
+                           " atomicity=" + atomicity);
+      }
+    }
+
+    file.close();
+
+    /* Delete the testfile.
+     * original file: unlink (filename);
+     * The second parameter is an info object.
+     */
+    MPI.COMM_WORLD.barrier();
+    File.delete(filename);
+
+    MPI.Finalize();
+
+    if ((myrank == 0) && DEBUG) {
+      System.out.println("myrank " + myrank + " of " + size +
+                         " MPI.Finalize() end");
+    }
+
+  }
+}

--- a/io/make_io
+++ b/io/make_io
@@ -14,7 +14,10 @@
 # File: make_io				Author: S. Gross
 #
 
-TWO_PROC="FileStatusGetCount"
+TWO_PROC="FileStatusGetCount \
+FileAll \
+FileAtAll \
+FileAtomicity"
 
 NUM_PROC=$TWO_PROC
 


### PR DESCRIPTION
open-mpi/ompi#3402 added missing Java binding methods to Open MPI.
These test programs correspond to those methods.

Signed-off-by: Tsubasa Yanagibashi <fj2505dt@aa.jp.fujitsu.com>